### PR TITLE
Ensure that no callbacks happen after endpoint is destroyed.

### DIFF
--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -272,6 +272,8 @@ public:
     // Misc Convenience Types
     typedef session::internal_state::value istate_type;
 
+    typedef lib::shared_ptr<void> endpoint_hdl;
+
 private:
     enum terminate_status {
         failed = 1,
@@ -281,7 +283,7 @@ private:
 public:
 
     explicit connection(bool p_is_server, std::string const & ua, alog_type& alog,
-        elog_type& elog, rng_type & rng)
+        elog_type& elog, rng_type & rng, endpoint_hdl endpoint)
       : transport_con_type(p_is_server, alog, elog)
       , m_handle_read_frame(lib::bind(
             &type::handle_read_frame,
@@ -309,6 +311,7 @@ public:
       , m_alog(alog)
       , m_elog(elog)
       , m_rng(rng)
+      , m_endpoint_hdl(endpoint)
       , m_local_close_code(close::status::abnormal_close)
       , m_remote_close_code(close::status::abnormal_close)
       , m_was_clean(false)
@@ -1479,6 +1482,8 @@ private:
     elog_type& m_elog;
 
     rng_type & m_rng;
+
+    endpoint_hdl m_endpoint_hdl;
 
     // Close state
     /// Close code that was sent on the wire by this endpoint

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -38,7 +38,8 @@ namespace websocketpp {
 
 /// Creates and manages connections associated with a WebSocket endpoint
 template <typename connection, typename config>
-class endpoint : public config::transport_type, public config::endpoint_base {
+class endpoint : public config::transport_type, public config::endpoint_base,
+    public lib::enable_shared_from_this<endpoint<connection, config> > {
 public:
     // Import appropriate types from our helper class
     // See endpoint_types for more details.
@@ -543,6 +544,10 @@ public:
     }
 protected:
     connection_ptr create_connection();
+
+    lib::shared_ptr<endpoint> get_shared() {
+      return this->shared_from_this();
+    }
 
     alog_type m_alog;
     elog_type m_elog;

--- a/websocketpp/impl/endpoint_impl.hpp
+++ b/websocketpp/impl/endpoint_impl.hpp
@@ -43,7 +43,8 @@ endpoint<connection,config>::create_connection() {
     //scoped_lock_type guard(m_mutex);
     // Create a connection on the heap and manage it using a shared pointer
     connection_ptr con = lib::make_shared<connection_type>(m_is_server,
-        m_user_agent, lib::ref(m_alog), lib::ref(m_elog), lib::ref(m_rng));
+        m_user_agent, lib::ref(m_alog), lib::ref(m_elog), lib::ref(m_rng),
+        lib::static_pointer_cast<void>(get_shared()));
 
     connection_weak_ptr w(con);
 

--- a/websocketpp/transport/asio/endpoint.hpp
+++ b/websocketpp/transport/asio/endpoint.hpp
@@ -97,7 +97,7 @@ public:
 
     ~endpoint() {
         // clean up our io_service if we were initialized with an internal one.
-        m_acceptor.reset();
+        cancel();
         if (m_state != UNINITIALIZED && !m_external_io_service) {
             delete m_io_service;
         }
@@ -1039,6 +1039,16 @@ protected:
         tcon->set_tcp_post_init_handler(m_tcp_post_init_handler);
 
         return lib::error_code();
+    }
+
+    void cancel() {
+        lib::error_code ec;
+        if (m_acceptor) {
+            m_acceptor->cancel(ec);
+        }
+        if (m_resolver) {
+            m_resolver->cancel();
+        }
     }
 private:
     /// Convenience method for logging the code and message for an error_code


### PR DESCRIPTION
A number of different async callbacks (timers and socket
read/write/accept notfications) were occurring after the client
and server were destroyed. This is problematic because connections
have references to loggers owned by the endpoint and were referencing
them after they were destroyed.

The server was also having its handle_accept method called with
a "cancelled" status after it was destroyed.

This change ensures that all of the endpoints callbacks are cancelled
before members they reference are destroyed, and it also makes the
connections hang onto a reference to the endpoint, ensuring that it
does not get destroyed before they do.
